### PR TITLE
feat: examples for Trustify tools

### DIFF
--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -28,6 +28,9 @@ uuid = { version = "1.6", features = ["v4", "serde"] }
 serde_urlencoded = "0.7"
 askama = { version = "0.14"}
 urlencoding = "2.1.3"
+trustify-module-fundamental = { git = "https://github.com/trustification/trustify.git", tag = "v0.2.19", package = "trustify-module-fundamental"}
+trustify-auth = { git = "https://github.com/trustification/trustify.git", tag = "v0.2.19", package = "trustify-auth"}
+openid = "0.16.1"
 # [dev-dependencies.'cfg(target_arch="linux")'.dependencies]
 
 [dev-dependencies]

--- a/examples/servers/Cargo.toml
+++ b/examples/servers/Cargo.toml
@@ -22,12 +22,12 @@ futures = "0.3"
 rand = { version = "0.8", features = ["std"] }
 axum = { version = "0.8", features = ["macros"] }
 schemars = { version = "0.8", optional = true }
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
 chrono = "0.4"
 uuid = { version = "1.6", features = ["v4", "serde"] }
 serde_urlencoded = "0.7"
 askama = { version = "0.14"}
-
+urlencoding = "2.1.3"
 # [dev-dependencies.'cfg(target_arch="linux")'.dependencies]
 
 [dev-dependencies]
@@ -62,3 +62,11 @@ path = "src/auth_sse.rs"
 [[example]]
 name = "mcp_oauth_server"
 path = "src/mcp_oauth_server.rs"
+
+[[example]]
+name = "servers_std_io_trustify"
+path = "src/std_io_trustify.rs"
+
+[[example]]
+name = "servers_axum_trustify"
+path = "src/axum_trustify.rs"

--- a/examples/servers/src/axum_trustify.rs
+++ b/examples/servers/src/axum_trustify.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{
 mod common;
 use common::trustify::Trustify;
 
-const BIND_ADDRESS: &str = "127.0.0.1:8081";
+const BIND_ADDRESS: &str = "[::]:8081";
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/servers/src/axum_trustify.rs
+++ b/examples/servers/src/axum_trustify.rs
@@ -1,0 +1,29 @@
+use rmcp::transport::sse_server::SseServer;
+use tracing_subscriber::{
+    layer::SubscriberExt,
+    util::SubscriberInitExt,
+    {self},
+};
+mod common;
+use common::trustify::Trustify;
+
+const BIND_ADDRESS: &str = "127.0.0.1:8081";
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "debug".to_string().into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let ct = SseServer::serve(BIND_ADDRESS.parse()?)
+        .await?
+        .with_service(Trustify::new);
+
+    tokio::signal::ctrl_c().await?;
+    ct.cancel();
+    Ok(())
+}

--- a/examples/servers/src/common/mod.rs
+++ b/examples/servers/src/common/mod.rs
@@ -1,3 +1,4 @@
 pub mod calculator;
 pub mod counter;
 pub mod generic_service;
+pub mod trustify;

--- a/examples/servers/src/common/trustify.rs
+++ b/examples/servers/src/common/trustify.rs
@@ -1,36 +1,82 @@
-use reqwest::blocking::Client;
+use reqwest::blocking::{Client, RequestBuilder, Response};
 use rmcp::{Error as McpError, Error, ServerHandler, const_string, model::*, schemars, tool};
+use serde::Serialize;
 use serde_json::Value;
+use std::collections::HashMap;
+use std::env;
+use tokio::sync::OnceCell;
+use trustify_auth::client::OpenIdTokenProvider;
+use trustify_module_fundamental::vulnerability::model::VulnerabilityDetails;
 
 #[derive(Clone)]
 pub struct Trustify {
     http_client: Client,
-    base_url: String,
+    api_base_url: String,
+    openid_issuer_url: String,
+    token_provider: OnceCell<OpenIdTokenProvider>,
+    open_client_id: String,
+    open_client_secret: String,
 }
 
 #[tool(tool_box)]
 impl Trustify {
     pub fn new() -> Self {
+        let api_base_url = env::var("API_URL").expect("Missing the API_URL environment variable.");
+        let openid_issuer_url = env::var("OPENID_ISSUER_URL")
+            .expect("Missing the OPENID_ISSUER_URL environment variable.");
+        let open_client_id = env::var("OPENID_CLIENT_ID")
+            .expect("Missing the OPENID_CLIENT_ID environment variable.");
+        let open_client_secret = env::var("OPENID_CLIENT_SECRET")
+            .expect("Missing the OPENID_CLIENT_SECRET environment variable.");
+
         // Initialize HTTP client
         let http_client = Client::builder()
             .user_agent("trustify-tools-server")
             .build()
             .expect("Failed to create HTTP client");
+
         Self {
             http_client,
-            base_url: "localhost:8080".to_string(),
+            api_base_url,
+            openid_issuer_url,
+            token_provider: OnceCell::default(),
+            open_client_id,
+            open_client_secret,
         }
     }
 
+    async fn get_token_provider(&self) -> OpenIdTokenProvider {
+        let client = openid::Client::discover(
+            self.open_client_id.clone(),
+            Some(self.open_client_secret.clone()),
+            None,
+            self.openid_issuer_url.parse().unwrap(),
+        )
+        .await
+        .unwrap();
+
+        OpenIdTokenProvider::new(client, chrono::Duration::seconds(240))
+    }
+
+    async fn get_bearer(&self) -> String {
+        self.token_provider
+            .get_or_init(|| self.get_token_provider())
+            .await
+            .provide_token()
+            .await
+            .unwrap()
+            .access_token
+    }
+
     #[tool(description = "Call the info endpoint for a trustify instance")]
-    fn trustify_info(&self) -> Result<CallToolResult, McpError> {
+    async fn trustify_info(&self) -> Result<CallToolResult, McpError> {
         // Trustify /.well-known/trustify URL
-        let url = format!("http://{}/.well-known/trustify", self.base_url);
-        self.call_url(url)
+        let url = format!("{}/.well-known/trustify", self.api_base_url);
+        self.get(url).await
     }
 
     #[tool(description = "Get a list of sboms from a trustify instance")]
-    fn trustify_sbom_list(
+    async fn trustify_sbom_list(
         &self,
         #[tool(param)]
         #[schemars(description = "Search query for sboms")]
@@ -40,14 +86,14 @@ impl Trustify {
         limit: usize,
     ) -> Result<CallToolResult, McpError> {
         let url = format!(
-            "http://{}/api/v2/sbom?q={}&limit={}",
-            self.base_url, query, limit
+            "{}/api/v2/sbom?q={}&limit={}",
+            self.api_base_url, query, limit
         );
-        self.call_url(url)
+        self.get(url).await
     }
 
     #[tool(description = "Get a list of packages contained in an sboms from a trustify instance")]
-    fn trustify_sbom_list_packages(
+    async fn trustify_sbom_list_packages(
         &self,
         #[tool(param)]
         #[schemars(description = "Sbom URI")]
@@ -60,45 +106,42 @@ impl Trustify {
         limit: usize,
     ) -> Result<CallToolResult, McpError> {
         let url = format!(
-            "http://{}/api/v2/sbom/{}/packages?q={}&limit={}",
-            self.base_url, sbom_uri, query, limit
+            "{}/api/v2/sbom/{}/packages?q={}&limit={}",
+            self.api_base_url, sbom_uri, query, limit
         );
-        self.call_url(url)
+        self.get(url).await
     }
 
     #[tool(
         description = "Provide the SBOM ID URN UUID to get a list of all the advisories with vulnerabilities related to an SBOM from a trustify instance"
     )]
-    fn trustify_sbom_list_advisories(
+    async fn trustify_sbom_list_advisories(
         &self,
         #[tool(param)]
         #[schemars(description = "Sbom URI")]
         sbom_uri: String,
     ) -> Result<CallToolResult, McpError> {
-        let url = format!("http://{}/api/v2/sbom/{}/advisory", self.base_url, sbom_uri);
-        self.call_url(url)
+        let url = format!("{}/api/v2/sbom/{}/advisory", self.api_base_url, sbom_uri);
+        self.get(url).await
     }
 
     #[tool(
         description = "Provide a package url-encoded PURL to get the list of vulnerabilities affecting if from a trustify instance"
     )]
-    fn trustify_purl_vulnerabilities(
+    async fn trustify_purl_vulnerabilities(
         &self,
         #[tool(param)]
         #[schemars(description = "Package URI or package PURL. Values must be url-encoded")]
         package_uri_or_purl: String,
     ) -> Result<CallToolResult, McpError> {
-        let url = format!(
-            "http://{}/api/v2/purl/{}",
-            self.base_url, package_uri_or_purl
-        );
-        self.call_url(url)
+        let url = format!("{}/api/v2/purl/{}", self.api_base_url, package_uri_or_purl);
+        self.get(url).await
     }
 
     #[tool(
         description = "Get a list of vulnerabilities from a trustify instance filtering them by severity and publication date and sorted by publish date"
     )]
-    fn trustify_vulnerabilities_list(
+    async fn trustify_vulnerabilities_list(
         &self,
         #[tool(param)]
         #[schemars(description = "Query for vulnerabilities, e.g. average_severity=critical|high")]
@@ -128,8 +171,8 @@ impl Trustify {
         sort_direction: String,
     ) -> Result<CallToolResult, McpError> {
         let url = format!(
-            "http://{}/api/v2/vulnerability?limit={}&offset=0&q={}%26published>{}%26published<{}&sort={}:{}",
-            self.base_url,
+            "{}/api/v2/vulnerability?limit={}&offset=0&q={}%26published>{}%26published<{}&sort={}:{}",
+            self.api_base_url,
             limit,
             query,
             published_after,
@@ -137,7 +180,52 @@ impl Trustify {
             sort_field,
             sort_direction
         );
-        self.call_url(url)
+        self.get(url).await
+    }
+
+    #[tool(
+        description = "Get a list of vulnerabilities from a trustify instance affecting the array of PURLs provided in input"
+    )]
+    async fn trustify_vulnerabilities_for_multiple_purls(
+        &self,
+        #[tool(param)]
+        #[schemars(
+            description = r#"Array of PURLs to be investigated for vulnerabilities.
+        The array must be delimited by square brackets [] and it must contain strings delimited by double quotes".
+        For example: ["pkg:maven/org.jenkins-ci.main/jenkins-core@2.145", "pkg:pypi/tensorflow-gpu@2.6.5"]"#
+        )]
+        purls: Vec<String>,
+    ) -> Result<CallToolResult, McpError> {
+        let mut purl_data = HashMap::new();
+        purl_data.insert("purls", purls);
+
+        let response = self
+            .post_raw(
+                format!("{}/api/v2/vulnerability/analyze", self.api_base_url),
+                &purl_data,
+            )
+            .await?;
+
+        // Parse the response
+        let vulnerability_details: HashMap<String, Vec<VulnerabilityDetails>> =
+            match response.json() {
+                Ok(response_json) => response_json,
+                Err(error) => {
+                    return Err(Error::internal_error(
+                        format!("Trustify API returned error: {:?}", error),
+                        None,
+                    ));
+                }
+            };
+
+        Ok(CallToolResult::success(vec![Content::json(
+            vulnerability_details,
+        )?]))
+        // let mut response = HashMap::new();
+        // for (purl, vulnerabilities) in vulnerability_details.iter() {
+        //     response.insert(purl, vulnerabilities[0].head.identifier.clone());
+        // }
+        // Ok(CallToolResult::success(vec![Content::json(response)?]))
     }
 
     #[tool(description = "URL encode a string")]
@@ -152,13 +240,52 @@ impl Trustify {
         )]))
     }
 
-    fn call_url(&self, url: String) -> Result<CallToolResult, Error> {
+    async fn get(&self, url: String) -> Result<CallToolResult, Error> {
+        self.call(self.http_client.get(url)).await
+    }
+
+    #[allow(dead_code)]
+    async fn post<T: Serialize + ?Sized>(
+        &self,
+        url: String,
+        json: &T,
+    ) -> Result<CallToolResult, Error> {
+        self.call(self.http_client.post(url).json(json)).await
+    }
+
+    async fn call(&self, request_builder: RequestBuilder) -> Result<CallToolResult, Error> {
+        // Call and get the response
+        let response = self.call_raw(request_builder).await?;
+
+        // Parse the response
+        let response_json: Value = match response.json() {
+            Ok(response_json) => response_json,
+            Err(error) => {
+                return Err(Error::internal_error(
+                    format!("Trustify API returned error: {:?}", error),
+                    None,
+                ));
+            }
+        };
+
+        Ok(CallToolResult::success(vec![Content::json(response_json)?]))
+    }
+
+    async fn post_raw<T: Serialize + ?Sized>(
+        &self,
+        url: String,
+        json: &T,
+    ) -> Result<Response, Error> {
+        self.call_raw(self.http_client.post(url).json(json)).await
+    }
+
+    async fn call_raw(&self, request_builder: RequestBuilder) -> Result<Response, Error> {
         // Send the request
-        let response = match self.http_client.get(url).send() {
+        let response = match request_builder.bearer_auth(self.get_bearer().await).send() {
             Ok(response) => response,
             Err(error) => {
                 return Err(Error::internal_error(
-                    format!("Trustify API returned error: {}", error),
+                    format!("Trustify API returned error: {:?}", error),
                     None,
                 ));
             }
@@ -172,21 +299,7 @@ impl Trustify {
             ));
         }
 
-        // Parse the response
-        let response_json: Value = match response.json() {
-            Ok(response_json) => response_json,
-            Err(error) => {
-                return Err(Error::internal_error(
-                    format!("Trustify API returned error: {}", error),
-                    None,
-                ));
-            }
-        };
-
-        Ok(CallToolResult::success(vec![Content::json(response_json)?]))
-        // Ok(CallToolResult::success(vec![Content::text(
-        //     response_json.to_string(),
-        // )]))
+        Ok(response)
     }
 }
 

--- a/examples/servers/src/common/trustify.rs
+++ b/examples/servers/src/common/trustify.rs
@@ -1,0 +1,206 @@
+use reqwest::blocking::Client;
+use rmcp::{Error as McpError, Error, ServerHandler, const_string, model::*, schemars, tool};
+use serde_json::Value;
+
+#[derive(Clone)]
+pub struct Trustify {
+    http_client: Client,
+    base_url: String,
+}
+
+#[tool(tool_box)]
+impl Trustify {
+    pub fn new() -> Self {
+        // Initialize HTTP client
+        let http_client = Client::builder()
+            .user_agent("trustify-tools-server")
+            .build()
+            .expect("Failed to create HTTP client");
+        Self {
+            http_client,
+            base_url: "localhost:8080".to_string(),
+        }
+    }
+
+    #[tool(description = "Call the info endpoint for a trustify instance")]
+    fn trustify_info(&self) -> Result<CallToolResult, McpError> {
+        // Trustify /.well-known/trustify URL
+        let url = format!("http://{}/.well-known/trustify", self.base_url);
+        self.call_url(url)
+    }
+
+    #[tool(description = "Get a list of sboms from a trustify instance")]
+    fn trustify_sbom_list(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Search query for sboms")]
+        query: String,
+        #[tool(param)]
+        #[schemars(description = "Maximum number of sboms to return")]
+        limit: usize,
+    ) -> Result<CallToolResult, McpError> {
+        let url = format!(
+            "http://{}/api/v2/sbom?q={}&limit={}",
+            self.base_url, query, limit
+        );
+        self.call_url(url)
+    }
+
+    #[tool(description = "Get a list of packages contained in an sboms from a trustify instance")]
+    fn trustify_sbom_list_packages(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Sbom URI")]
+        sbom_uri: String,
+        #[tool(param)]
+        #[schemars(description = "Search query for packages within the SBOM")]
+        query: String,
+        #[tool(param)]
+        #[schemars(description = "Maximum number of packages to return")]
+        limit: usize,
+    ) -> Result<CallToolResult, McpError> {
+        let url = format!(
+            "http://{}/api/v2/sbom/{}/packages?q={}&limit={}",
+            self.base_url, sbom_uri, query, limit
+        );
+        self.call_url(url)
+    }
+
+    #[tool(
+        description = "Provide the SBOM ID URN UUID to get a list of all the advisories with vulnerabilities related to an SBOM from a trustify instance"
+    )]
+    fn trustify_sbom_list_advisories(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Sbom URI")]
+        sbom_uri: String,
+    ) -> Result<CallToolResult, McpError> {
+        let url = format!("http://{}/api/v2/sbom/{}/advisory", self.base_url, sbom_uri);
+        self.call_url(url)
+    }
+
+    #[tool(
+        description = "Provide a package url-encoded PURL to get the list of vulnerabilities affecting if from a trustify instance"
+    )]
+    fn trustify_purl_vulnerabilities(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Package URI or package PURL. Values must be url-encoded")]
+        package_uri_or_purl: String,
+    ) -> Result<CallToolResult, McpError> {
+        let url = format!(
+            "http://{}/api/v2/purl/{}",
+            self.base_url, package_uri_or_purl
+        );
+        self.call_url(url)
+    }
+
+    #[tool(
+        description = "Get a list of vulnerabilities from a trustify instance filtering them by severity and publication date and sorted by publish date"
+    )]
+    fn trustify_vulnerabilities_list(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Query for vulnerabilities, e.g. average_severity=critical|high")]
+        query: String,
+        #[tool(param)]
+        #[schemars(description = "Maximum number of packages to return, default 1000")]
+        limit: usize,
+        #[tool(param)]
+        #[schemars(
+            description = "Date after which the vulnerability has to be published, provided in the format 2025-04-20T22:00:00.000Z"
+        )]
+        published_after: String,
+        #[tool(param)]
+        #[schemars(
+            description = "Date before which the vulnerability has to be published, provided in the format 2025-04-20T22:00:00.000Z"
+        )]
+        published_before: String,
+        #[tool(param)]
+        #[schemars(
+            description = "Field used to sort the vulnerabilities in the output, e.g. 'published'"
+        )]
+        sort_field: String,
+        #[tool(param)]
+        #[schemars(
+            description = "Sort direction, values allowed are only 'desc' and 'asc', default is 'desc'"
+        )]
+        sort_direction: String,
+    ) -> Result<CallToolResult, McpError> {
+        let url = format!(
+            "http://{}/api/v2/vulnerability?limit={}&offset=0&q={}%26published>{}%26published<{}&sort={}:{}",
+            self.base_url,
+            limit,
+            query,
+            published_after,
+            published_before,
+            sort_field,
+            sort_direction
+        );
+        self.call_url(url)
+    }
+
+    #[tool(description = "URL encode a string")]
+    fn url_encode(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "String to be URL encoded")]
+        input: String,
+    ) -> Result<CallToolResult, McpError> {
+        Ok(CallToolResult::success(vec![Content::text(
+            urlencoding::encode(input.as_str()),
+        )]))
+    }
+
+    fn call_url(&self, url: String) -> Result<CallToolResult, Error> {
+        // Send the request
+        let response = match self.http_client.get(url).send() {
+            Ok(response) => response,
+            Err(error) => {
+                return Err(Error::internal_error(
+                    format!("Trustify API returned error: {}", error),
+                    None,
+                ));
+            }
+        };
+
+        // Check if the request was successful
+        if !response.status().is_success() {
+            return Err(Error::internal_error(
+                format!("Trustify API returned status code: {}", response.status()),
+                None,
+            ));
+        }
+
+        // Parse the response
+        let response_json: Value = match response.json() {
+            Ok(response_json) => response_json,
+            Err(error) => {
+                return Err(Error::internal_error(
+                    format!("Trustify API returned error: {}", error),
+                    None,
+                ));
+            }
+        };
+
+        Ok(CallToolResult::success(vec![Content::json(response_json)?]))
+        // Ok(CallToolResult::success(vec![Content::text(
+        //     response_json.to_string(),
+        // )]))
+    }
+}
+
+const_string!(Echo = "echo");
+#[tool(tool_box)]
+impl ServerHandler for Trustify {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo {
+            protocol_version: ProtocolVersion::V_2024_11_05,
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .build(),
+            server_info: Implementation::from_build_env(),
+            instructions: Some("This server provides tools for interacting with a Trustify remote instance. The tools are able to retrieve info about the Trustify instance itself, the list of the SBOMs ingested, the packages and the vulnerabilities related to each SBOM. Further it can retrieve the vulnerabilities information ingested. More information about Trustify at https://github.com/trustification/trustify".to_string()),
+        }
+    }
+}

--- a/examples/servers/src/common/trustify.rs
+++ b/examples/servers/src/common/trustify.rs
@@ -144,7 +144,7 @@ impl Trustify {
     async fn trustify_vulnerabilities_list(
         &self,
         #[tool(param)]
-        #[schemars(description = "Query for vulnerabilities, e.g. average_severity=critical|high")]
+        #[schemars(description = "Query for vulnerabilities, e.g. base_severity=critical|high")]
         query: String,
         #[tool(param)]
         #[schemars(description = "Maximum number of packages to return, default 1000")]

--- a/examples/servers/src/std_io_trustify.rs
+++ b/examples/servers/src/std_io_trustify.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use common::trustify::Trustify;
+use rmcp::{ServiceExt, transport::stdio};
+use tracing_subscriber::{self, EnvFilter};
+
+mod common;
+/// npx @modelcontextprotocol/inspector cargo run -p mcp-server-examples --example std_io_trustify
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize the tracing subscriber with file and stdout logging
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive(tracing::Level::DEBUG.into()))
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .init();
+
+    tracing::info!("Starting MCP server");
+
+    // Create an instance of Trustify tools
+    let service = Trustify::new().serve(stdio()).await.inspect_err(|e| {
+        tracing::error!("serving error: {:?}", e);
+    })?;
+
+    service.waiting().await?;
+    Ok(())
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85"
+channel = "1.86"
 components = ["rustc", "rust-std", "cargo", "clippy", "rustfmt", "rust-docs"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86"
+channel = "1.87"
 components = ["rustc", "rust-std", "cargo", "clippy", "rustfmt", "rust-docs"]


### PR DESCRIPTION
Sample code developed to have a Trustify MCP server working with both transport layers, i.e. stdio and sse.

# Testing the MCP Server stdio with Claude Desktop

1. build the MCP server executing `cargo build --release --example servers_std_io_trustify`
2. configure Claude Desktop to use Trustify MCP Server going to `Settings` => `Developer` => `Edit config` and editing the `claude_desktop_config.json` file adding:
   ```json
   {
     "mcpServers": {
       "trustify": {
         "command": "<path to rust-sdk repo>/target/release/examples/servers_std_io_trustify",
         "args": []
       }
     }
   }
   ```
3. restart Claude Desktop and the tools will be available

# Runing the MCP Server SSE

1. execute `cargo run --release --example servers_axum_trustify` and the server will be available at http://localhost:8081/sse